### PR TITLE
Force CURL to use TLS1.2 for S3 calls

### DIFF
--- a/src/S3.php
+++ b/src/S3.php
@@ -23,7 +23,8 @@ class S3 {
         $this->curl_opts = array(
             CURLOPT_CONNECTTIMEOUT => 30,
             CURLOPT_LOW_SPEED_LIMIT => 1,
-            CURLOPT_LOW_SPEED_TIME => 30
+            CURLOPT_LOW_SPEED_TIME => 30,
+            CURLOPT_SSLVERSION => 6,  // Force requsts to use TLS 1.2
         );
     }
 


### PR DESCRIPTION
AWS is requiring TLS1.2+ for CURL connections to S3.